### PR TITLE
Development/CI_CD_artefact_caching

### DIFF
--- a/.github/workflows/macos-arm-latest.yaml
+++ b/.github/workflows/macos-arm-latest.yaml
@@ -22,7 +22,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_CACHE_MULTIARCH: 1 # for macos actions only!
   HOMEBREW_NO_INSTALL_CLEANUP: 1
-  STONEYDSP_BIQUADS_CURRENT_VERSION: 0.0.1
+  STONEYDSP_BIQUADS_CURRENT_VERSION: 1.2.0
   STONEYDSP_CURRENT_JUCE_VERSION: 7.0.9
 
 jobs:
@@ -174,14 +174,14 @@ jobs:
     - name: Upload Zip Build
       uses: actions/upload-artifact@v4
       with:
-        name: StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-arm64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip
-        path: '${{ github.workspace }}/install/StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-arm64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip'
+        name: StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-arm64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip
+        path: '${{ github.workspace }}/install/StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-arm64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip'
 
     - name: Upload Tar Build
       uses: actions/upload-artifact@v4
       with:
-        name: StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-arm64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.tar.gz
-        path: '${{ github.workspace }}/install/StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-arm64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.tar.gz'
+        name: StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-arm64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.tar.gz
+        path: '${{ github.workspace }}/install/StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-arm64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.tar.gz'
 
     - name: Get Artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/macos-latest.yaml
+++ b/.github/workflows/macos-latest.yaml
@@ -22,7 +22,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_CACHE_MULTIARCH: 1 # for macos actions only!
   HOMEBREW_NO_INSTALL_CLEANUP: 1
-  STONEYDSP_BIQUADS_CURRENT_VERSION: 0.0.1
+  STONEYDSP_BIQUADS_CURRENT_VERSION: 1.2.0
   STONEYDSP_CURRENT_JUCE_VERSION: 7.0.9
 
 jobs:
@@ -174,14 +174,14 @@ jobs:
     - name: Upload Zip Build
       uses: actions/upload-artifact@v4
       with:
-        name: StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-x86_64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip
-        path: '${{ github.workspace }}/install/StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-x86_64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip'
+        name: StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-x86_64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip
+        path: '${{ github.workspace }}/install/StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-x86_64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip'
 
     - name: Upload Tar Build
       uses: actions/upload-artifact@v4
       with:
-        name: StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-x86_64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.tar.gz
-        path: '${{ github.workspace }}/install/StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-x86_64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.tar.gz'
+        name: StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-x86_64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.tar.gz
+        path: '${{ github.workspace }}/install/StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Darwin-x86_64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.tar.gz'
 
     - name: Get Artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/windows-latest.yaml
+++ b/.github/workflows/windows-latest.yaml
@@ -20,7 +20,7 @@ env:
   VCPKG_MAX_CONCURRENCY: 3
   SCCACHE_GHA_ENABLED: "true"
   IPP_DIR: C:\Program Files (x86)\Intel\oneAPI\ipp\latest\lib\cmake\ipp
-  STONEYDSP_BIQUADS_CURRENT_VERSION: 0.0.1
+  STONEYDSP_BIQUADS_CURRENT_VERSION: 1.2.0
   STONEYDSP_CURRENT_JUCE_VERSION: 7.0.9
 
 jobs:
@@ -168,8 +168,8 @@ jobs:
     - name: Upload Zip Build
       uses: actions/upload-artifact@v4
       with:
-        name: StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Windows-AMD64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip
-        path: '${{ github.workspace }}/install/StoneyDSP-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Windows-AMD64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip'
+        name: StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Windows-AMD64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip
+        path: '${{ github.workspace }}/install/StoneyDSP-Biquads-v${{ env.STONEYDSP_BIQUADS_CURRENT_VERSION }}-Windows-AMD64-JUCE-v${{ env.STONEYDSP_CURRENT_JUCE_VERSION }}.zip'
 
     - name: Get Artifacts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed artefact caching for GitHub actions.

## What is the current behavior?

No build artefacts uploaded due to broken Actions config.

## What is the new behavior?

Build artefacts are now uploaded to the repository artefact cache.
